### PR TITLE
Fix deprecated method name

### DIFF
--- a/sortbyfield/SortByFieldPlugin.php
+++ b/sortbyfield/SortByFieldPlugin.php
@@ -20,7 +20,7 @@ class SortByFieldPlugin extends BasePlugin
         return 'http://dannynimmo.co.nz/';
     }
 
-    public function hookAddTwigExtension() {
+    public function addTwigExtension() {
         Craft::import('plugins.sortbyfield.twigextensions.SortByFieldTwigExtension');
         return new SortByFieldTwigExtension();
     }


### PR DESCRIPTION
The current version of Craft generates the following log warning: 

[warning] [application] The “hook” prefix on the Craft\SortByFieldPlugin::hookAddTwigExtension() method name has been deprecated. It should be renamed to addTwigExtension().

The attached commit fixes that :-)
